### PR TITLE
Fix `useSelector` not updating when selector changes Fixes #1

### DIFF
--- a/src/hooks/use-selector.ts
+++ b/src/hooks/use-selector.ts
@@ -50,6 +50,10 @@ export function useSelector<State = {}, Selected = unknown>(
 	const store = useStore<Rodux.Store<State>>();
 	const [selectedState, setSelectedState] = useState<Selected>(() => selector(store.getState()));
 
+	useEffect(() => {
+		setSelectedState(store.getState())
+	}, [selector])
+
 	const latestSelectedState = useMutable<Selected>(selectedState);
 	useEffect(() => {
 		latestSelectedState.current = selectedState;
@@ -65,7 +69,7 @@ export function useSelector<State = {}, Selected = unknown>(
 			}
 		});
 		return () => signal.disconnect();
-	}, []);
+	}, [selector]);
 
 	return selectedState;
 }

--- a/src/hooks/use-selector.ts
+++ b/src/hooks/use-selector.ts
@@ -51,7 +51,7 @@ export function useSelector<State = {}, Selected = unknown>(
 	const [selectedState, setSelectedState] = useState<Selected>(() => selector(store.getState()));
 
 	useEffect(() => {
-		setSelectedState(store.getState())
+		setSelectedState(selector(store.getState()))
 	}, [selector])
 
 	const latestSelectedState = useMutable<Selected>(selectedState);


### PR DESCRIPTION
Possible concerns with this approach:

- Runs the selector twice on first re-render (due to the `useState` and the initial `useEffect` both running)
- Might re-run every re-render if you do `useSelector((state) => ...)` due to the callback being different ..?